### PR TITLE
Feature add readiness and liveness probes

### DIFF
--- a/config/samples/cache_v1alpha1_rediscluster.yaml
+++ b/config/samples/cache_v1alpha1_rediscluster.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   masters: 3
   replicasPerMaster: 1
+  config: |
+    maxmemory 200mb
+    maxmemory-policy allkeys-lru

--- a/internal/kubernetes/statefulset.go
+++ b/internal/kubernetes/statefulset.go
@@ -89,6 +89,32 @@ func createStatefulsetSpec(cluster *v1alpha1.RedisCluster) *v1.StatefulSet {
 									ContainerPort: 16379,
 								},
 							},
+							LivenessProbe: &v12.Probe{
+								ProbeHandler: v12.ProbeHandler{
+									Exec: &v12.ExecAction{
+										Command: []string{
+											"redis-cli",
+											"ping",
+										},
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       3,
+							},
+							ReadinessProbe: &v12.Probe{
+								ProbeHandler: v12.ProbeHandler{
+									Exec: &v12.ExecAction{
+										Command: []string{
+											"redis-cli",
+											"ping",
+										},
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       3,
+							},
 							VolumeMounts: []v12.VolumeMount{
 								{
 									Name:      "redis-cluster-config",

--- a/internal/kubernetes/statefulset_test.go
+++ b/internal/kubernetes/statefulset_test.go
@@ -218,3 +218,22 @@ func TestCreateStatefulset_MountsConfigMapAsVolumeCorrectly(t *testing.T) {
 		t.Fatalf("Configmap mounted on wrong directory in redis pod")
 	}
 }
+
+func TestCreateStatefulset_SetsLivenessAndReadinessProbes(t *testing.T) {
+	// Register operator types with the runtime scheme.
+	cluster := &cachev1alpha1.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis-cluster",
+			Namespace: "default",
+		},
+	}
+	statefulset := createStatefulsetSpec(cluster)
+
+	if statefulset.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+		t.Fatalf("Readiness probe not set on the Redis statefulset")
+	}
+
+	if statefulset.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+		t.Fatalf("Liveness probe not set on the Redis statefulset")
+	}
+}


### PR DESCRIPTION
Adds Readiness and Liveness probes for Redis containers. 

This makes sure that when we fetch pods and check readiness in the Operator, we can be sure that Redis is running and responding in that pod, which allows us to avoid having to do a bunch of checks in the operator.

Closes #8 